### PR TITLE
Fixes #44: Last item hide behind bottom nav fixed

### DIFF
--- a/apikey.properties
+++ b/apikey.properties
@@ -1,1 +1,1 @@
-API_KEY="replace this with your api key"
+API_KEY="buyTPvbuxa4HNCJQzDLUj5ndoZWFVZ8d46fsSBXi"

--- a/apikey.properties
+++ b/apikey.properties
@@ -1,1 +1,1 @@
-API_KEY="buyTPvbuxa4HNCJQzDLUj5ndoZWFVZ8d46fsSBXi"
+API_KEY="replace this with your api key"

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/home/HomeFragment.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.github.code.gambit.R
 import com.github.code.gambit.data.model.File
 import com.github.code.gambit.data.model.Url
@@ -144,10 +145,30 @@ class HomeFragment : Fragment(R.layout.fragment_home), FileUrlClickCallback, Bot
     }
 
     private fun setUpFileRecyclerView() {
-        binding.fileList.layoutManager = LinearLayoutManager(requireContext())
+        val layoutManager = LinearLayoutManager(requireContext())
+        binding.fileList.layoutManager = layoutManager
         binding.fileList.setHasFixedSize(false)
         binding.fileList.adapter = adapter
         adapter.listener = this
+        binding.fileList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                if (searchBinding.root.isVisible) {
+                    super.onScrolled(recyclerView, dx, dy)
+                    return
+                }
+                if (dy > 0) {
+                    hideBottomNav()
+                } else {
+                    showBottomNav()
+                }
+                if (!recyclerView.canScrollVertically(1) && layoutManager.findLastVisibleItemPosition() == layoutManager.itemCount - 1) {
+                    // shortToast("End of list")
+                    println()
+                }
+                Timber.tag("home").i("(dx: $dx, dy: $dy)")
+                super.onScrolled(recyclerView, dx, dy)
+            }
+        })
     }
 
     private fun registerUrlComponent() {


### PR DESCRIPTION
Fixes #44 

**Description**
Added auto-hide bottom nav functionality based on scrolling. Now whenever the user scrolls down bottonNav hides automatically and whenever scrolls up it comes back. 
1. Added scroll change listener in recycler view

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them