### PR TITLE
forgot password feature added

### DIFF
--- a/app/src/main/java/com/github/code/gambit/data/remote/services/auth/AuthService.kt
+++ b/app/src/main/java/com/github/code/gambit/data/remote/services/auth/AuthService.kt
@@ -10,6 +10,8 @@ interface AuthService {
     suspend fun signUp(authData: AuthData): ServiceResult<Unit>
     suspend fun logOut(): ServiceResult<Unit>
     suspend fun resetPassword(oldPassword: String, newPassword: String): ServiceResult<Unit>
+    suspend fun forgotPassword(userEmail: String): ServiceResult<Unit>
+    suspend fun changePassword(newPassword: String, confirmationCode: String): ServiceResult<Unit>
     suspend fun updateUserName(fullName: String): ServiceResult<String>
     suspend fun confirmSignUp(authData: AuthData): ServiceResult<Unit>
     suspend fun fetchSession(): ServiceResult<AWSCognitoAuthSession>

--- a/app/src/main/java/com/github/code/gambit/data/remote/services/auth/AuthServiceImpl.kt
+++ b/app/src/main/java/com/github/code/gambit/data/remote/services/auth/AuthServiceImpl.kt
@@ -58,6 +58,27 @@ class AuthServiceImpl : AuthService {
         }
     }
 
+    override suspend fun forgotPassword(userEmail: String): ServiceResult<Unit> {
+        return try {
+            Amplify.Auth.resetPassword(userEmail)
+            ServiceResult.Success(Unit)
+        } catch (e: java.lang.Exception) {
+            ServiceResult.Error(e)
+        }
+    }
+
+    override suspend fun changePassword(
+        newPassword: String,
+        confirmationCode: String
+    ): ServiceResult<Unit> {
+        return try {
+            Amplify.Auth.confirmResetPassword(newPassword, confirmationCode)
+            ServiceResult.Success(Unit)
+        } catch (e: java.lang.Exception) {
+            ServiceResult.Error(e)
+        }
+    }
+
     override suspend fun updateUserName(fullName: String): ServiceResult<String> {
         return try {
             val attribute = AuthUserAttribute(AuthUserAttributeKey.name(), fullName)

--- a/app/src/main/java/com/github/code/gambit/helper/auth/AuthState.kt
+++ b/app/src/main/java/com/github/code/gambit/helper/auth/AuthState.kt
@@ -3,6 +3,7 @@ package com.github.code.gambit.helper.auth
 sealed class AuthState<out T> {
     data class Success<out T>(val data: T) : AuthState<T>()
     data class Error(val reason: String) : AuthState<Nothing>()
+    data class ResendStatus(val success: Boolean) : AuthState<Nothing>()
     object Loading : AuthState<Nothing>()
     object Confirmation : AuthState<Nothing>()
     object CodeMissMatch : AuthState<Nothing>()

--- a/app/src/main/java/com/github/code/gambit/repositories/auth/AuthRepository.kt
+++ b/app/src/main/java/com/github/code/gambit/repositories/auth/AuthRepository.kt
@@ -10,4 +10,7 @@ interface AuthRepository {
     suspend fun signUp(authData: AuthData): ServiceResult<Unit>
     suspend fun logOut(): ServiceResult<Unit>
     suspend fun signUpConfirmation(authData: AuthData): ServiceResult<User>
+    suspend fun resendConfirmationCode(userEmail: String): ServiceResult<Unit>
+    suspend fun forgotPassword(userEmail: String): ServiceResult<Unit>
+    suspend fun resetForgotPassword(authData: AuthData): ServiceResult<User>
 }

--- a/app/src/main/java/com/github/code/gambit/repositories/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/github/code/gambit/repositories/auth/AuthRepositoryImpl.kt
@@ -13,7 +13,6 @@ import com.github.code.gambit.utility.sharedpreference.UserManager
 import java.lang.Exception
 
 class AuthRepositoryImpl
-
 constructor(
     private val authService: AuthService,
     private val networkDataSource: NetworkDataSource,
@@ -81,5 +80,20 @@ constructor(
         }
         (confirmationResult as ServiceResult.Success)
         return login(authData)
+    }
+
+    override suspend fun resendConfirmationCode(userEmail: String): ServiceResult<Unit> {
+        return authService.resentConfirmationCode(userEmail)
+    }
+
+    override suspend fun forgotPassword(userEmail: String): ServiceResult<Unit> {
+        return authService.forgotPassword(userEmail)
+    }
+
+    override suspend fun resetForgotPassword(authData: AuthData): ServiceResult<User> {
+        return when (val res = authService.changePassword(authData.password, authData.confirmationCode!!)) {
+            is ServiceResult.Error -> res
+            is ServiceResult.Success -> login(authData)
+        }
     }
 }

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/auth/LoginFragment.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/auth/LoginFragment.kt
@@ -3,15 +3,28 @@ package com.github.code.gambit.ui.fragment.auth
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.github.code.gambit.R
 import com.github.code.gambit.databinding.FragmentLoginBinding
 import com.github.code.gambit.helper.auth.AuthData
+import com.github.code.gambit.helper.auth.AuthState
+import com.github.code.gambit.ui.fragment.auth.confirmationcomponent.ConfirmationComponent
+import com.github.code.gambit.utility.extention.longToast
 import com.github.code.gambit.utility.extention.snackbar
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class LoginFragment : Fragment(R.layout.fragment_login) {
 
     private lateinit var _binding: FragmentLoginBinding
     val binding get() = _binding
+
+    private val viewModel: AuthViewModel by viewModels()
+
+    private lateinit var confirmationComponent: ConfirmationComponent
+
+    private var authData: AuthData? = null
 
     val username get() = binding.usernameInput.editText?.text.toString().trim()
     val password get() = binding.passwordInput.editText?.text.toString().trim()
@@ -19,6 +32,71 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentLoginBinding.bind(view)
+        binding.linearProgress.hide()
+        confirmationComponent = ConfirmationComponent.bind(requireContext())
+
+        binding.forgotPasswordText.setOnClickListener {
+            authData = validateFormForForgotPassword()
+            authData?.let {
+                viewModel.setEvent(AuthEvent.ForgotPassword(it.email))
+            }
+        }
+        confirmationComponent.getOtp().observe(viewLifecycleOwner) {
+            it?.let { otp ->
+                authData?.let { data ->
+                    viewModel.setEvent(AuthEvent.ResetForgotPassword(data.email, data.password, otp))
+                }
+            }
+        }
+        confirmationComponent.setResendCallback { email ->
+            viewModel.setEvent(AuthEvent.ForgotPassword(email))
+        }
+
+        viewModel.authState.observe(viewLifecycleOwner) {
+            when (it) {
+                AuthState.CodeMissMatch -> confirmationComponent.showError("Invalid code!!")
+                AuthState.Confirmation -> confirmationComponent.show(authData?.email ?: "")
+                is AuthState.Error -> binding.root.snackbar(it.reason)
+                AuthState.Loading -> binding.linearProgress.show()
+                is AuthState.Success -> {
+                    binding.root.snackbar("Welcome ${it.data.name}")
+                    if (this::confirmationComponent.isInitialized && confirmationComponent.isShowing()) {
+                        confirmationComponent.exit { findNavController().navigate(R.id.action_authFragment_to_homeFragment) }
+                    }
+                }
+                is AuthState.ResendStatus -> {
+                    if (it.success) {
+                        longToast("Code send on your email")
+                    } else {
+                        longToast("Code send failed")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun validateFormForForgotPassword(): AuthData? {
+        var error = false
+        if (username == "") {
+            binding.usernameInput.error = "Enter User email here"
+            error = true
+        } else {
+            if (binding.usernameInput.isErrorEnabled) {
+                binding.usernameInput.isErrorEnabled = false
+            }
+        }
+        if (password == "") {
+            binding.passwordInput.error = "Enter new password"
+            error = true
+        } else {
+            if (binding.passwordInput.isErrorEnabled) {
+                binding.passwordInput.isErrorEnabled = false
+            }
+        }
+        if (error) {
+            return null
+        }
+        return AuthData("", username, password, null, null)
     }
 
     // validates the input fields

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationComponent.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationComponent.kt
@@ -1,0 +1,18 @@
+package com.github.code.gambit.ui.fragment.auth.confirmationcomponent
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+
+interface ConfirmationComponent {
+    companion object {
+        fun bind(context: Context): ConfirmationDialog {
+            return ConfirmationDialog(context)
+        }
+    }
+    fun isShowing(): Boolean
+    fun show(userEmail: String)
+    fun exit(exitFunction: () -> Unit = {})
+    fun getOtp(): LiveData<String>
+    fun setResendCallback(callback: (email: String) -> Unit)
+    fun showError(message: String = "")
+}

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationDialog.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationDialog.kt
@@ -1,0 +1,148 @@
+package com.github.code.gambit.ui.fragment.auth.confirmationcomponent
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewAnimationUtils
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.github.code.gambit.R
+import com.github.code.gambit.databinding.EmailVerificationLayoutBinding
+import com.github.code.gambit.utility.extention.setStatusColor
+import com.github.code.gambit.utility.extention.snackbar
+import kotlin.math.hypot
+
+class ConfirmationDialog(val context: Context) : ConfirmationComponent {
+
+    private var dialog: Dialog = Dialog(context, R.style.Theme_VTransfer)
+
+    private var _binding: EmailVerificationLayoutBinding = EmailVerificationLayoutBinding.bind(
+        LayoutInflater.from(context).inflate(R.layout.email_verification_layout, null)
+    )
+    private val binding get() = _binding
+
+    private val _otp = MutableLiveData<String>()
+    private var resendCallBack: ((email: String) -> Unit)? = null
+
+    private var userEmail: String = ""
+
+    init {
+        dialog.setContentView(binding.root)
+
+        dialog.window?.setStatusColor(
+            ContextCompat.getColor(
+                context,
+                R.color.secondary
+            )
+        )
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        binding.validate.setOnClickListener {
+            val otp = binding.otpView.otp
+            otp?.let {
+                if (otp.length != 6) {
+                    snackbar("Invalid code length")
+                    showError()
+                } else {
+                    binding.progressBar.show()
+                    binding.validate.isClickable = false
+                    _otp.value = it
+                }
+            } ?: snackbar("Code can't be empty")
+        }
+
+        binding.cancel.setOnClickListener {
+            revealShow(b = false, exit = true)
+        }
+
+        binding.resend.setOnClickListener {
+            resendCallBack?.let { it(userEmail) }
+        }
+
+        dialog.setOnShowListener { revealShow(true) }
+
+        dialog.setOnKeyListener(
+            DialogInterface.OnKeyListener { _, i, _ ->
+                if (i == KeyEvent.KEYCODE_BACK) {
+                    revealShow(false)
+                    return@OnKeyListener true
+                }
+                false
+            }
+        )
+    }
+
+    private fun revealShow(b: Boolean, exit: Boolean = false, exitFunction: () -> Unit = {}) {
+        val view = binding.root
+        val w = view.width
+        val h = view.height
+        val endRadius = hypot(w.toDouble(), h.toDouble()).toInt()
+        val cx = (view.width / 2)
+        val cy = 0
+        if (b) {
+            val revealAnimator =
+                ViewAnimationUtils.createCircularReveal(view, cx, cy, 0f, endRadius.toFloat())
+            view.visibility = View.VISIBLE
+            revealAnimator.duration = 700
+            revealAnimator.start()
+        } else {
+            val anim =
+                ViewAnimationUtils.createCircularReveal(view, cx, cy, endRadius.toFloat(), 0f)
+            anim.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    super.onAnimationEnd(animation)
+                    if (exit) {
+                        dialog.dismiss()
+                        view.visibility = View.INVISIBLE
+                        exitFunction()
+                    }
+                }
+            })
+            anim.duration = 700
+            anim.start()
+        }
+    }
+
+    private fun snackbar(message: String) {
+        binding.root.snackbar(message)
+    }
+
+    override fun isShowing() = dialog.isShowing
+
+    @SuppressLint("SetTextI18n")
+    override fun show(userEmail: String) {
+        this.userEmail = userEmail
+        binding.infoText.text = "${binding.infoText.text}\n$userEmail"
+        dialog.show()
+    }
+
+    override fun exit(exitFunction: () -> Unit) {
+        revealShow(b = false, exit = true, exitFunction = exitFunction)
+    }
+
+    override fun getOtp(): LiveData<String> {
+        return _otp
+    }
+
+    override fun setResendCallback(callback: (email: String) -> Unit) {
+        resendCallBack = callback
+    }
+
+    override fun showError(message: String) {
+        binding.validate.isClickable = true
+        binding.progressBar.hide()
+        binding.otpView.showError()
+        if (message.isNotEmpty()) {
+            snackbar(message)
+        }
+    }
+}

--- a/app/src/main/res/layout/email_verification_layout.xml
+++ b/app/src/main/res/layout/email_verification_layout.xml
@@ -28,7 +28,9 @@
         android:textSize="12sp"
         android:textColor="@color/raw_black"
         android:fontFamily="sans-serif"
-        android:layout_below="@id/verification_code_text"/>
+        android:layout_below="@id/verification_code_text"
+        android:textAlignment="center"
+        android:maxLines="2"/>
     <TextView
         android:id="@+id/email_text"
         android:layout_width="wrap_content"
@@ -52,18 +54,43 @@
         android:layout_centerHorizontal="true"
         android:layout_below="@id/email_text"/>
 
-    <TextView
+    <Button
         android:id="@+id/validate"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_alignParentBottom="true"
+        android:layout_above="@id/cancel"
         android:letterSpacing="0.1"
         android:textStyle="bold"
         android:textSize="14sp"
-        android:layout_marginBottom="64dp"
+        android:layout_marginBottom="@dimen/root_side_margin"
         android:textColor="@color/raw_black"
         android:text="@string/validate"/>
+
+    <Button
+        android:id="@+id/cancel"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="36dp"
+        android:text="@string/cancel"
+        android:textColor="@color/raw_black"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="32dp"/>
+
+
+    <Button
+        android:id="@+id/resend"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="36dp"
+        android:text="@string/resend"
+        android:textColor="@color/raw_black"
+        android:layout_below="@id/otp_view"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/root_side_margin"/>
+
 
     <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress_bar"

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -93,19 +93,34 @@
 
     </LinearLayout>
 
-
-    <TextView
-        android:id="@+id/forgot_password_text"
-        android:layout_width="match_parent"
+    <LinearLayout
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginBottom="32dp"
-        android:text="@string/forgot_password"
-        android:textColor="@color/black"
-        android:textSize="14sp"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout2" />
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="32dp">
 
+
+        <TextView
+            android:id="@+id/forgot_password_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/forgot_password"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            />
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/linear_progress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            app:indicatorColor="@color/secondary"
+            android:layout_marginTop="@dimen/root_side_margin"/>
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,5 @@
     <string name="uploaded">Uploaded</string>
     <string name="between">between</string>
     <string name="space">&#160;</string>
+    <string name="resend">Resend</string>
 </resources>


### PR DESCRIPTION
Fixes #83 

**Description**
1. Code verification moved to a separate component.
2. Login fragment now has a separate verification component for forget password event.
3. User can now resend the code multiple times when signing in for the first time.
4. Users can now change their password in case forgotten from the login page.
5. Minor changes in code verification UI.
6. New auth services added for forgetting passwords.


**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them