### PR TITLE
State fixed while authenticating

### DIFF
--- a/app/src/main/java/com/github/code/gambit/ui/fragment/auth/AuthFragment.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/auth/AuthFragment.kt
@@ -51,7 +51,8 @@ class AuthFragment : Fragment(R.layout.fragment_auth) {
             if (it) {
                 Toast.makeText(requireContext(), "Permission granted", Toast.LENGTH_SHORT).show()
             } else {
-                Toast.makeText(requireContext(), "Permission not granted", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), "Permission not granted", Toast.LENGTH_SHORT)
+                    .show()
             }
         }
 
@@ -72,14 +73,14 @@ class AuthFragment : Fragment(R.layout.fragment_auth) {
         confirmationComponent = ConfirmationComponent.bind(requireContext())
 
         confirmationComponent.getOtp().observe(viewLifecycleOwner) {
-            it?.let {
-                confirmSignUp(it)
-            }
+            it?.let { confirmSignUp(it) }
         }
 
         confirmationComponent.setResendCallback { email ->
             viewModel.setEvent(AuthEvent.ResendCode(email))
         }
+
+        confirmationComponent.setOnCancelCallback { enableInteraction() }
 
         binding.buttonSubmit.setOnClickListener {
             disableInteraction()
@@ -90,12 +91,16 @@ class AuthFragment : Fragment(R.layout.fragment_auth) {
                 val data = (fg as SignUpFragment).validate()
                 if (data != null) {
                     signUp(data)
-                } else { enableInteraction() }
+                } else {
+                    enableInteraction()
+                }
             } else {
                 val data = (fg as LoginFragment).validate()
                 if (data != null) {
                     logIn(data)
-                } else { enableInteraction() }
+                } else {
+                    enableInteraction()
+                }
             }
         }
 
@@ -128,6 +133,7 @@ class AuthFragment : Fragment(R.layout.fragment_auth) {
                         binding.root.snackbar(it.reason)
                     }
                     is AuthState.ResendStatus -> {
+                        confirmationComponent.onResendResult(it.success)
                         if (it.success) {
                             longToast("Code send on your email")
                         }

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationComponent.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/auth/confirmationcomponent/ConfirmationComponent.kt
@@ -15,4 +15,6 @@ interface ConfirmationComponent {
     fun getOtp(): LiveData<String>
     fun setResendCallback(callback: (email: String) -> Unit)
     fun showError(message: String = "")
+    fun setOnCancelCallback(cancelFunction: () -> Unit = {})
+    fun onResendResult(success: Boolean)
 }

--- a/app/src/main/java/com/github/code/gambit/utility/extention/view.kt
+++ b/app/src/main/java/com/github/code/gambit/utility/extention/view.kt
@@ -5,6 +5,7 @@ import android.app.AlertDialog
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.os.Handler
 import android.view.View
 import android.view.Window
 import android.view.WindowManager
@@ -12,8 +13,8 @@ import android.view.animation.AnimationUtils
 import android.view.animation.DecelerateInterpolator
 import android.view.inputmethod.InputMethodManager
 import android.widget.RelativeLayout
+import android.widget.TextView
 import android.widget.Toast
-import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.github.code.gambit.R
@@ -58,20 +59,33 @@ fun View?.show() {
     }
 }
 
+fun View?.enableAfter(timeInSeconds: Int, counterView: TextView) {
+    if (this == null) {
+        return
+    }
+    var count = timeInSeconds
+    this.isEnabled = false
+    counterView.visibility = View.VISIBLE
+    Handler().post(object : Runnable {
+        override fun run() {
+            counterView.text = count.toString()
+            if (count <= 0) {
+                this@enableAfter.isEnabled = true
+                counterView.visibility = View.INVISIBLE
+                return
+            }
+            count--
+            handler.postDelayed(this, 1000)
+        }
+    })
+}
+
 fun View.toggleVisibility() {
     if (isVisible) {
         visibility = View.GONE
         return
     }
     visibility = View.VISIBLE
-}
-
-fun List<View>.hideAll() {
-    this.forEach { it.hide() }
-}
-
-fun List<View>.showAll() {
-    this.forEach { it.show() }
 }
 
 fun View.snackbar(message: String, view: View) {
@@ -152,8 +166,13 @@ fun Context.showDefaultAlert(title: String, message: String, positiveButtonPress
         .setNegativeButton("Cancel") { dialog, _ -> dialog.dismiss() }.create().show()
 }
 
-fun Context.showDefaultMaterialAlert(title: String, message: String, positiveButtonPress: () -> Unit) {
+fun Context.showDefaultMaterialAlert(
+    title: String,
+    message: String,
+    positiveButtonPress: () -> Unit
+) {
     MaterialAlertDialogBuilder(this)
-        .setTitle(title).setMessage(message).setPositiveButton("Yes") { _, _ -> positiveButtonPress() }
+        .setTitle(title).setMessage(message)
+        .setPositiveButton("Yes") { _, _ -> positiveButtonPress() }
         .setNegativeButton("Cancel") { dialog, _ -> dialog.dismiss() }.create().show()
 }

--- a/app/src/main/res/layout/email_verification_layout.xml
+++ b/app/src/main/res/layout/email_verification_layout.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/secondary"
     android:id="@+id/root">
 
@@ -79,6 +80,18 @@
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="32dp"/>
 
+    <TextView
+        android:id="@+id/resend_timer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="47"
+        android:textSize="22sp"
+        android:fontFamily="sans-serif-light"
+        android:textColor="@color/raw_black"
+        android:layout_below="@id/otp_view"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/root_side_margin"/>
+
 
     <Button
         android:id="@+id/resend"
@@ -87,9 +100,10 @@
         android:layout_height="36dp"
         android:text="@string/resend"
         android:textColor="@color/raw_black"
-        android:layout_below="@id/otp_view"
+        android:layout_below="@id/resend_timer"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="@dimen/root_side_margin"/>
+        android:layout_marginTop="2dp"
+        android:enabled="false"/>
 
 
     <com.google.android.material.progressindicator.CircularProgressIndicator
@@ -97,7 +111,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:indeterminate="true"
-        android:layout_centerInParent="true"
+        android:layout_below="@id/resend"
+        android:layout_centerHorizontal="true"
         android:visibility="gone"
         app:indicatorColor="@color/login_signup_button_color"/>
 


### PR DESCRIPTION
Fixes #91 

**Description**
- State of components fixed while authenticating.
- Added new state where `RESEND` button is disabled for first 50sec.
- Minor UI changes to support above feature.

[![](https://img.shields.io/badge/APK-Download-blue?style=for-the-badge&logo=android)](<add apk link here>)

**Please Add Screenshots If there are any UI changes.**
<img width='222' alt='ss' src='https://user-images.githubusercontent.com/31315800/121764420-5bf54900-cb61-11eb-9e37-7b4526c1e7c1.png'>  <img width='222' alt='ss' src='https://user-images.githubusercontent.com/31315800/121764421-5c8ddf80-cb61-11eb-936c-2c6f51a164f9.png'> <img width='222' alt='ss' src='https://user-images.githubusercontent.com/31315800/121764418-58fa5880-cb61-11eb-8000-0c1bd1b12caa.png'> 

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them