### PR TITLE
focus change listener changed to text watcher

### DIFF
--- a/app/src/main/java/com/github/code/gambit/ui/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/activity/main/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
+import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
@@ -24,8 +25,8 @@ import com.github.code.gambit.databinding.ActivityMainBinding
 import com.github.code.gambit.helper.file.FileUploadState
 import com.github.code.gambit.ui.OnItemClickListener
 import com.github.code.gambit.ui.fragment.BottomNavController
-import com.github.code.gambit.ui.fragment.auth.AuthFragment
 import com.github.code.gambit.ui.fragment.home.main.HomeFragment
+import com.github.code.gambit.ui.fragment.profile.ProfileFragment
 import com.github.code.gambit.utility.SystemManager
 import com.github.code.gambit.utility.extention.bottomNavHide
 import com.github.code.gambit.utility.extention.bottomNavShow
@@ -75,6 +76,10 @@ class MainActivity : AppCompatActivity(), BottomNavController {
         binding.root.addTransitionListener(object : MotionLayout.TransitionListener {
             override fun onTransitionStarted(p0: MotionLayout?, p1: Int, p2: Int) {
                 hideKeyboard()
+                val frag = getCurrentFragment()
+                if (frag is ProfileFragment) {
+                    frag.looseFocus()
+                }
             }
 
             override fun onTransitionChange(p0: MotionLayout?, p1: Int, p2: Int, p3: Float) {}
@@ -213,36 +218,33 @@ class MainActivity : AppCompatActivity(), BottomNavController {
 
     override fun onBackPressed() {
         if (!userManager.isAuthenticated()) {
-            val fragment =
-                supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container)?.childFragmentManager?.fragments?.first()
-            if (fragment is AuthFragment && fragment.currentPage != 0) {
-                fragment.setPage(0)
-                return
-            }
             super.onBackPressed()
             return
         }
-        val hostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container)
-        if (hostFragment is NavHostFragment) {
-            when (val fragment = hostFragment.childFragmentManager.fragments.first()) {
-                is HomeFragment -> {
-                    when {
-                        fragment.isFilterEnable() -> {
-                            fragment.closeFilter()
-                        }
-                        fragment.isSearchEnable() -> {
-                            fragment.closeSearch()
-                        }
-                        else -> {
-                            finish()
-                        }
+        when (val fragment = getCurrentFragment()) {
+            is HomeFragment -> {
+                when {
+                    fragment.isFilterEnable() -> {
+                        fragment.closeFilter()
+                    }
+                    fragment.isSearchEnable() -> {
+                        fragment.closeSearch()
+                    }
+                    else -> {
+                        finish()
                     }
                 }
-                else -> super.onBackPressed()
             }
-        } else {
-            super.onBackPressed()
+            else -> super.onBackPressed()
         }
+    }
+
+    fun getCurrentFragment(): Fragment? {
+        val hostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container)
+        if (hostFragment is NavHostFragment) {
+            return hostFragment.childFragmentManager.fragments.first()
+        }
+        return null
     }
 
     fun getAddFab(): View {

--- a/app/src/main/java/com/github/code/gambit/ui/fragment/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/github/code/gambit/ui/fragment/profile/ProfileFragment.kt
@@ -1,6 +1,8 @@
 package com.github.code.gambit.ui.fragment.profile
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -31,6 +33,8 @@ class ProfileFragment : Fragment(R.layout.fragment_profile) {
 
     private lateinit var changePasswordListener1: View.OnClickListener
     private lateinit var changePasswordListener2: View.OnClickListener
+
+    private var isFirstEdit = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -73,14 +77,27 @@ class ProfileFragment : Fragment(R.layout.fragment_profile) {
     }
 
     private fun setClickListeners() {
-        binding.fullName.editText?.setOnFocusChangeListener { _, b ->
-            if (b) {
-                binding.cancelButton.show()
-                binding.doneButton.show()
+        binding.fullName.editText?.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                if (!isFirstEdit) {
+                    binding.cancelButton.show()
+                    binding.doneButton.show()
+                    if (s.toString() == user.name) {
+                        binding.cancelButton.hide()
+                        binding.doneButton.hide()
+                    }
+                } else {
+                    isFirstEdit = false
+                }
             }
-        }
+
+            override fun afterTextChanged(s: Editable?) {}
+        })
         binding.cancelButton.setOnClickListener {
             looseFocus()
+            it.hide()
             binding.fullName.setText(user.name)
             if (binding.oldPassword.isVisible) {
                 binding.passwordContainer.hide()
@@ -143,7 +160,7 @@ class ProfileFragment : Fragment(R.layout.fragment_profile) {
         return true
     }
 
-    private fun looseFocus() {
+    fun looseFocus() {
         binding.cancelButton.hide()
         binding.doneButton.hide()
         binding.fullName.editText!!.clearFocus()


### PR DESCRIPTION
Fixes #92 

**Description**
- Focus change listener removed. Now text watcher is used for altering view states.
- Added focus management specifically for profile fragment, which make sure to handle focus properly.
- Minor code optimisation.

[![](https://img.shields.io/badge/APK-Download-blue?style=for-the-badge&logo=android)](https://we.tl/t-EyZj3fV3hI)


**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them