### PR TITLE
Fixes #117 : scroll behaviour fixed in profile page

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -9,7 +9,8 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginBottom="130dp">
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">


### PR DESCRIPTION
Fixes #117 

**Description**
Added bottom margin to make sure profile page scroll behaviour triggers as soon layout hides behind bottom nav bar.


**Please Add Screenshots If there are any UI changes.**
<img width='333' alt='ss' src='https://user-images.githubusercontent.com/31315800/123642929-7ad22b80-d841-11eb-80d1-09362e1ce2fd.png'>

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them